### PR TITLE
Validate input

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,18 @@
 'use strict';
+const isDefined = x => x !== null && x !== undefined;
+
 module.exports = (month, year) => {
+	if (isDefined(month) && typeof month !== 'number') {
+		throw new TypeError(`Expected \`month\` to be of type \`number\`, got \`${typeof month}\``);
+	}
+
+	if (isDefined(year) && typeof year !== 'number') {
+		throw new TypeError(`Expected \`year\` to be of type \`number\`, got \`${typeof year}\``);
+	}
+
 	const now = new Date();
-	month = (month === null || month === undefined) ? now.getUTCMonth() : month;
-	year = (year === null || year === undefined) ? now.getUTCFullYear() : year;
+	month = isDefined(month) ? month : now.getUTCMonth();
+	year = isDefined(year) ? year : now.getUTCFullYear();
 
 	return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
 };

--- a/test.js
+++ b/test.js
@@ -2,6 +2,9 @@ import test from 'ava';
 import m from './';
 
 test(t => {
+	t.throws(() => m('5'), TypeError);
+	t.throws(() => m(false), TypeError);
+	t.throws(() => m(5, true), TypeError);
 	t.is(m(5, 2014), 30);
 	t.is(m(5), 30);
 	t.true(m() >= 28);


### PR DESCRIPTION
Throwing an explicit error message when the input is defined and is not a `number`.